### PR TITLE
Use globus

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,31 +392,9 @@ boxes = h5f[&quot;boxes&quot;] # (1460,15,5) numpy array</code></pre></div>
 <p><a name="download"></a></p>
 
 <ul>
-<li>  1979: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1979.h5">climo_1979.h5</a> (62 GB)</li>
-<li>  1980: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1980.h5">climo_1980.h5</a> (62 GB)</li>
-<li>  1981: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1981.h5">climo_1981.h5</a> (62 GB)</li>
-<li><p>1982: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1982.h5">climo_1982.h5</a> (62 GB)</p></li>
-<li><p>1984: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1984.h5">climo_1984.h5</a> (62 GB)</p></li>
-<li><p>1985: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1985.h5">climo_1985.h5</a> (62 GB)</p></li>
-<li><p>1986: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1986.h5">climo_1986.h5</a> (62 GB)</p></li>
-<li><p>1987: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1987.h5">climo_1987.h5</a> (62 GB)</p></li>
-<li><p>1988: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1988.h5">climo_1988.h5</a> (62 GB)</p></li>
-<li><p>1989: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1989.h5">climo_1989.h5</a> (62 GB)</p></li>
-<li><p>1990: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1990.h5">climo_1990.h5</a> (62 GB)</p></li>
-<li><p>1991: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1991.h5">climo_1991.h5</a> (62 GB)</p></li>
-<li><p>1992: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1992.h5">climo_1992.h5</a> (62 GB)</p></li>
-<li><p>1993: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1993.h5">climo_1993.h5</a> (62 GB)</p></li>
-<li><p>1994: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1994.h5">climo_1994.h5</a> (62 GB)</p></li>
-<li><p>1995: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1995.h5">climo_1995.h5</a> (62 GB)</p></li>
-<li><p>1996: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1996.h5">climo_1996.h5</a> (62 GB)</p></li>
-<li><p>1997: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1997.h5">climo_1997.h5</a> (62 GB)</p></li>
-<li><p>1998: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1998.h5">climo_1998.h5</a> (62 GB)</p></li>
-<li><p>2000: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2000.h5">climo_2000.h5</a> (62 GB)</p></li>
-<li><p>2001: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2001.h5">climo_2001.h5</a> (62 GB)</p></li>
-<li><p>2002: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2002.h5">climo_2002.h5</a> (62 GB)</p></li>
-<li><p>2003: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2003.h5">climo_2003.h5</a> (62 GB)</p></li>
-<li><p>2004: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2004.h5">climo_2004.h5</a> (62 GB)</p></li>
-<li><p>2005: <a href="http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2005.h5">climo_2005.h5</a> (62 GB)</p></li>
+    <li>The files are large (62 GB each).  Obtain them from <a href="https://app.globus.org/file-manager?origin_id=89a33dca-e540-11e9-9bfc-0a19784404f4&origin_path=%2F">this Globus endpoint.</a></li>
+    <li>You will need a Globus endpoint of your own for the transfer.</li>
+    <li>Alternatively you may use <a href="https://www.globus.org/globus-connect-personal">Globus Connect Personal.</a></li>
 </ul>
 
 <h3 id="toc_5">Additional Info</h3>

--- a/index.md
+++ b/index.md
@@ -56,33 +56,9 @@ The two variables, "images" and "boxes" are described below:
 
 <a name="download"></a>
 
-*   1979: [climo_1979.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1979.h5) (62 GB)
-*   1980: [climo_1980.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1980.h5) (62 GB)
-*   1981: [climo_1981.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1981.h5) (62 GB)
-*   1982: [climo_1982.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1982.h5) (62 GB)
-
-*   1984: [climo_1984.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1984.h5) (62 GB)
-*   1985: [climo_1985.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1985.h5) (62 GB)
-*   1986: [climo_1986.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1986.h5) (62 GB)
-*   1987: [climo_1987.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1987.h5) (62 GB)
-*   1988: [climo_1988.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1988.h5) (62 GB)
-*   1989: [climo_1989.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1989.h5) (62 GB)
-*   1990: [climo_1990.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1990.h5) (62 GB)
-*   1991: [climo_1991.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1991.h5) (62 GB)
-*   1992: [climo_1992.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1992.h5) (62 GB)
-*   1993: [climo_1993.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1993.h5) (62 GB)
-*   1994: [climo_1994.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1994.h5) (62 GB)
-*   1995: [climo_1995.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1995.h5) (62 GB)
-*   1996: [climo_1996.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1996.h5) (62 GB)
-*   1997: [climo_1997.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1997.h5) (62 GB)
-*   1998: [climo_1998.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_1998.h5) (62 GB)
-
-*   2000: [climo_2000.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2000.h5) (62 GB)
-*   2001: [climo_2001.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2001.h5) (62 GB)
-*   2002: [climo_2002.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2002.h5) (62 GB)
-*   2003: [climo_2003.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2003.h5) (62 GB)
-*   2004: [climo_2004.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2004.h5) (62 GB)
-*   2005: [climo_2005.h5](http://portal.nersc.gov/project/dasrepo/DO_NOT_REMOVE/extremeweather_dataset/h5data/climo_2005.h5) (62 GB)
+* The files are large (62 GB each).  Obtain them from [this Globus endpoint.](https://app.globus.org/file-manager?origin_id=89a33dca-e540-11e9-9bfc-0a19784404f4&origin_path=%2F)
+* You will need a Globus endpoint of your own for the transfer.
+* Alternatively you may use [Globus Connect Personal.](https://www.globus.org/globus-connect-personal)
 
 ### Additional Info
 


### PR DESCRIPTION
Unfortunately we need to stop hosting these files this way.  Globus for these kinds of large files is the best approach.  The old files have been moved to the endpoint, so right now the data is not accessible at all.  To ensure continuity of access, approve this PR.  Thank you!